### PR TITLE
Fix for upgrading to Swift 2.2

### DIFF
--- a/SwiftyEvents/Emittable.swift
+++ b/SwiftyEvents/Emittable.swift
@@ -7,9 +7,9 @@
 //
 
 public protocol Emittable {
-    typealias EventType: Hashable
-    typealias ValueType: Any
-    typealias FunctionType = ValueType -> Void
+    associatedtype EventType: Hashable
+    associatedtype ValueType: Any
+    associatedtype FunctionType = ValueType -> Void
     
     func on(event: EventType, _ function: FunctionType) -> Listener<ValueType>
     func on(event: EventType, listener: Listener<ValueType>) -> Listener<ValueType>

--- a/SwiftyEventsTests/EventEmitterTests.swift
+++ b/SwiftyEventsTests/EventEmitterTests.swift
@@ -174,7 +174,7 @@ class EventEmitterTests: XCTestCase {
         var ca = 0
         
         let fa = { (value: String) -> Void in
-            ca++
+            ca += 1
             
             XCTAssertEqual(val, value, "Call function with argument")
         }
@@ -182,7 +182,7 @@ class EventEmitterTests: XCTestCase {
         var cb = 0
         
         let fb = { (value: String) -> Void in
-            cb++
+            cb += 1
             
             XCTAssertEqual(val, value, "Call function with argument")
         }


### PR DESCRIPTION
Replace "typealias" keyword to "associatedtype".
Replace "++" to "+= 1".
